### PR TITLE
Allow specifying current working directory

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    scallop (0.9.0)
+    scallop (0.9.1)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/scallop/command_builder.rb
+++ b/lib/scallop/command_builder.rb
@@ -42,8 +42,8 @@ module Scallop
       cmd(:|, other.read_cmd)
     end
 
-    def run
-      Executor.run(to_command)
+    def run(args = {})
+      Executor.run(to_command, args)
     end
 
     def run!

--- a/lib/scallop/executor.rb
+++ b/lib/scallop/executor.rb
@@ -3,15 +3,15 @@
 module Scallop
   # Executes command and returns result.
   module Executor
-    def self.run(command)
+    def self.run(command, args = {})
       capture3, timing = measure do
-        Open3.capture3(command)
+        Open3.capture3(command, args)
       end
       build_result(capture3, timing)
     end
 
-    def self.run!(command)
-      run(command).tap do |result|
+    def self.run!(command, args = {})
+      run(command, args).tap do |result|
         raise Errors::CommandFailed.new(result.stderr, result) unless result.success?
       end
     end
@@ -27,8 +27,8 @@ module Scallop
 
       Result
         .new(
-          stdout: stdout.strip,
-          stderr: stderr.strip,
+          stdout: stdout.to_s.strip,
+          stderr: stderr.to_s.strip,
           status: status,
           timing: timing,
         )

--- a/lib/scallop/version.rb
+++ b/lib/scallop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Scallop
-  VERSION = '0.9.0'
+  VERSION = '0.9.1'
 end

--- a/spec/scallop_spec.rb
+++ b/spec/scallop_spec.rb
@@ -99,6 +99,11 @@ RSpec.describe Scallop do
       expect(result.output).to include('No such file or directory')
       expect(result.success?).to eq false
     end
+
+    specify 'working directory specified' do
+      expect(Open3).to receive(:capture3).with("ls -l", chdir: "/some/path")
+      Scallop.cmd(:ls, "-l").run(chdir: "/some/path")
+    end
   end
 
   describe '#run!' do


### PR DESCRIPTION
This just passes through additional args to the Open3 api:

```ruby
cmd = Scallop.cmd(:git, :status, "--porcelain").run(chdir: repo_path)
```

I am not sure this is the best way, but it starts the conversation at least.

