### PR TITLE
Support passing environment variables to commands

### DIFF
--- a/lib/scallop/command_builder.rb
+++ b/lib/scallop/command_builder.rb
@@ -46,8 +46,8 @@ module Scallop
       Executor.run(to_command, args)
     end
 
-    def run!
-      Executor.run!(to_command)
+    def run!(args = {})
+      Executor.run!(to_command, args)
     end
 
     def to_command

--- a/lib/scallop/executor.rb
+++ b/lib/scallop/executor.rb
@@ -5,7 +5,11 @@ module Scallop
   module Executor
     def self.run(command, args = {})
       capture3, timing = measure do
-        Open3.capture3(command, args)
+        if args[:env]
+          Open3.capture3(args.delete(:env), command, args)
+        else
+          Open3.capture3(command, args)
+        end
       end
       build_result(capture3, timing)
     end

--- a/spec/scallop_spec.rb
+++ b/spec/scallop_spec.rb
@@ -104,6 +104,12 @@ RSpec.describe Scallop do
       expect(Open3).to receive(:capture3).with("ls -l", chdir: "/some/path")
       Scallop.cmd(:ls, "-l").run(chdir: "/some/path")
     end
+
+    specify 'passing custom environment variables' do
+      env_vars = { 'FOO' => 'BAR' }
+      expect(Open3).to receive(:capture3).with(env_vars, "ls -l")
+      Scallop.cmd(:ls, "-l").run(env: env_vars)
+    end
   end
 
   describe '#run!' do

--- a/spec/scallop_spec.rb
+++ b/spec/scallop_spec.rb
@@ -107,8 +107,11 @@ RSpec.describe Scallop do
 
     specify 'passing custom environment variables' do
       env_vars = { 'FOO' => 'BAR' }
-      expect(Open3).to receive(:capture3).with(env_vars, "ls -l")
-      Scallop.cmd(:ls, "-l").run(env: env_vars)
+      command = Scallop.cmd(:env) | Scallop.cmd(:grep, 'FOO')
+      result = command.run(env: env_vars)
+
+      expect(result.success?).to eq true
+      expect(result.stdout).to eq 'FOO=BAR'
     end
   end
 


### PR DESCRIPTION
Minor improvement to allow passing custom environment variables to commands.

Also updates `CommandBuilder#run!` to support arguments, in parity with `CommandBuilder#run`